### PR TITLE
Var var jade breaks javascript output

### DIFF
--- a/templatizer.js
+++ b/templatizer.js
@@ -29,7 +29,7 @@ module.exports = function (templateDirectory, outputFile, watch) {
         'var root = this, exports = {};',
         '',
         '// The jade runtime:',
-        + jadeRuntime,
+        jadeRuntime,
         ''
     ].join('\n');
 


### PR DESCRIPTION
var var jade = "" appeared in the compiled javascript output which caused the script to break. Fixed by removing the initial var. 
