### PR TITLE
Fixes #1 - add RequireJS support

### DIFF
--- a/templatizer.js
+++ b/templatizer.js
@@ -82,6 +82,8 @@ module.exports = function (templateDirectory, outputFile, watch) {
         '// attach to window or export with commonJS',
         'if (typeof module !== "undefined") {',
         '    module.exports = exports;',
+        '} else if (typeof define === "function" && define.amd) {',
+        '    define(exports);',
         '} else {',
         '    root.templatizer = exports;',
         '}',


### PR DESCRIPTION
Opted for the simple approach - just added a line to the bottom that checks for `define` to be a function and `define.amd` to exist.
