### PR TITLE
Replaced findit with walkdir, overcomes substack/node-findit#5

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "jade": "",
         "uglify-js": "",
-        "findit": "",
+        "walkdir": "",
         "underscore": "",
         "colors": "",
         "yetify": ""

--- a/templatizer.js
+++ b/templatizer.js
@@ -1,6 +1,6 @@
 var jade = require('jade'),
     uglifyjs = require('uglify-js'),
-    findit = require('findit'),
+    walkdir = require('walkdir'),
     path = require('path'),
     _ = require('underscore'),
     fs = require('fs');
@@ -24,7 +24,7 @@ module.exports = function (templateDirectory, outputFile, watch) {
         jadeRuntime = fs.readFileSync(__dirname + '/node_modules/jade/runtime.min.js');
     }
     
-    contents = findit.sync(templateDirectory);
+    contents = walkdir.sync(templateDirectory);
 
     
     output = [


### PR DESCRIPTION
substack/node-findit seems not to be actively developed anymore, thus replaced the package with the same API/functionality soldair/node-walkdir

Should fix numerous problems, with the main being omitted directories and files in Windows7 (substack/node-findit#5)
