### PR TITLE
Fixed .DS_Store error

### DIFF
--- a/templatizer.js
+++ b/templatizer.js
@@ -32,7 +32,7 @@ module.exports = function (templateDirectory, outputFile, watch) {
 
     contents.forEach(function (file) {
         item = file.replace(templateDirectory, '').slice(1);
-        if (path.extname(item) === '' && item.charAt(0) !== '.') {
+        if (path.extname(item) === '' && path.basename(item).charAt(0) !== '.') {
             folders.push(item);
         } else if (path.extname(item) === '.jade') {
             templates.push(item);


### PR DESCRIPTION
Fixed a bug that results in the following behavior:

If there's a .DS_Store inside a folder in the templates path it, will create a bad folder name that includes the string .DS_Store.

The folders array will look like this:

[ 'folderOne',
  'folderTwo',
  'folderTwo/.DS_Store' ]

By isolating the base name in the path before checking for hidden files, you can avoid this error.
