### PR TITLE
Exposing jade through template exports

### DIFF
--- a/templatizer.js
+++ b/templatizer.js
@@ -26,7 +26,7 @@ module.exports = function (templateDirectory, outputFile, watch) {
             'var root = this, exports = {};',
             '',
             '// The jade runtime:',
-            'var ' + jadeRuntime,
+            'var jade = exports.' + jadeRuntime,
             ''
         ].join('\n');
 


### PR DESCRIPTION
Exporting jade to allow for things like version checking, or modifications to internal methods.
