### PR TITLE
Fixing issue with nested dir mixins using incorrect object key

### DIFF
--- a/lib/jade-ast.js
+++ b/lib/jade-ast.js
@@ -183,7 +183,7 @@ module.exports.getMixins = function (options) {
             mixinOutput += [
                 '',
                 '// ' + name + '.jade:' + declarationName + ' compiled template',
-                '' + parentObjName + '["' + dirString + '"]["' + declarationName.replace(rIsMixin, '').replace(/\./g, '"]["') + '"] = ' + generatedMixinFn + ';',
+                '' + parentObjName + '["' + dirString.replace(/\./g, '"]["') + '"]["' + declarationName.replace(rIsMixin, '').replace(/\./g, '"]["') + '"] = ' + generatedMixinFn + ';',
                 ''
             ].join('\n');
         }


### PR DESCRIPTION
Addresses an issue with mixins defined in a nested directory using bad keys.

For a template `foo/bar.jade` to have a mixin defined:

Before: `exports["foo.bar"]["mixin"] = function(){}`
After: `exports["foo"]["bar"]["mixin"] = function(){}`

Sorry theres no test for this, not sure how you guys are running tests... nudge nudge.
