### PR TITLE
Updating function naming regex to replace all non-letter non-number char

### DIFF
--- a/lib/jade-ast.js
+++ b/lib/jade-ast.js
@@ -104,7 +104,7 @@ var transformMixinCall = function (statement, ns) {
 
 module.exports.renameFunc = function (func, name) {
     var ast = esprima.parse(func);
-    ast.body[0].id.name = 'tmpl_' + name.replace(/\./g, '_');
+    ast.body[0].id.name = 'tmpl_' + name.replace(/[^A-Za-z0-9]/g, '_');
     return escodegen.generate(ast);
 };
 
@@ -137,7 +137,7 @@ module.exports.getMixins = function (options) {
             fnTree.type = 'FunctionDeclaration';
             fnTree.id = {
                 type: 'Identifier',
-                name: 'tmpl_' + dirString.replace(/\./g, '_') + '_' + declarationName
+                name: 'tmpl_' + dirString.replace(/[^A-Za-z0-9]/g, '_') + '_' + declarationName
             };
             statements = fnTree.body.body;
 


### PR DESCRIPTION
Fixes an issue when naming functions from files with `-` in the name.
