### PR TITLE
added simple templates reformatting

### DIFF
--- a/lib/jade-ast.js
+++ b/lib/jade-ast.js
@@ -92,11 +92,13 @@ var transformMixinCall = function (statement, ns) {
         }
 
         // Add namespaced callee as the argument
-        statement.expression.arguments = [{
-            type: 'CallExpression',
-            callee: JSON.parse(newCallee),
-            arguments: oldArgs
-        }];
+        statement.expression.arguments = [
+            {
+                type: 'CallExpression',
+                callee: JSON.parse(newCallee),
+                arguments: oldArgs
+            }
+        ];
     }
 
     return statement;
@@ -107,6 +109,54 @@ module.exports.renameFunc = function (func, name) {
     ast.body[0].id.name = 'tmpl_' + name.replace(/[^A-Za-z0-9]/g, '_');
     return escodegen.generate(ast);
 };
+
+
+module.exports.simplifyTemplate = function (func) {
+    var ast = esprima.parse(func);
+
+    var funcRoot = ast.body[0].body.body;
+    if (funcRoot.length === 3) {
+        //determine if there are only the buf declaration, the push of one string and then the return of the buf.join
+        var simple = false;
+        var simpleString = '';
+        try {
+            /* check for buf declare */
+            if (funcRoot[0].type === "VariableDeclaration" && funcRoot[0].declarations[0].id.name === "buf" &&
+                (funcRoot[0].declarations[0].init.elements instanceof Array && funcRoot[0].declarations[0].init.elements.length === 0)) {
+                /* check for single string push */
+                if (funcRoot[1].type === "ExpressionStatement" && funcRoot[1].expression.callee.object.name === "buf" &&
+                    funcRoot[1].expression.arguments.length === 1 && funcRoot[1].expression.arguments[0].type === "Literal") {
+                    /* save the simple string */
+                    simpleString = funcRoot[1].expression.arguments[0].value;
+                    /* check for buf join */
+                    if (funcRoot[2].type === "ReturnStatement" && funcRoot[2].argument.callee.object.name === "buf" &&
+                        funcRoot[2].argument.callee.property.name === "join" && funcRoot[2].argument.arguments.length === 1  && funcRoot[2].argument.arguments[0].value === '') {
+                        simple = true;
+                    }
+                }
+            }
+        }
+        catch (e) {
+            simple = false;
+        }
+
+        if (simple) {
+            //replace the funcRoot with a simple return;
+            var simpleRoot = [{
+                type: 'ReturnStatement',
+                argument: {
+                    type: 'Literal',
+                    value: simpleString
+                }
+            }];
+            ast.body[0].body.body = simpleRoot;
+
+            //remove function parameter
+            ast.body[0].params = [];
+        }
+    }
+    return escodegen.generate(ast);
+}
 
 module.exports.getMixins = function (options) {
     var ast = esprima.parse(options.template);

--- a/templatizer.js
+++ b/templatizer.js
@@ -82,6 +82,7 @@ module.exports = function (templateDirectories, outputFile, dontTransformMixins)
             pretty: false,
             filename: item
         }).toString());
+
         template = jadeAst.renameFunc(template, dirString);
 
         var astResult = jadeAst.getMixins({
@@ -93,6 +94,8 @@ module.exports = function (templateDirectories, outputFile, dontTransformMixins)
 
         mixinOutput = astResult.mixins;
         if (!dontTransformMixins) template = astResult.template;
+
+        template = jadeAst.simplifyTemplate(template);
 
         output += [
             '',


### PR DESCRIPTION
Added some basic AST checking to rewrite templates that are static & simple (issue #24)

It follows the same format as @HenrikJoreteg suggests, however it also removes the _locals_ parameter (as it is unecessary)
