### PR TITLE
Fix for issue with Windows environment path separators, possible fix for...

### DIFF
--- a/templatizer.js
+++ b/templatizer.js
@@ -71,9 +71,8 @@ module.exports = function (templateDirectories, outputFile, dontTransformMixins)
             });
             var dirname = path.dirname(item).replace(itemTemplateDir, '');
             if (dirname === '.') return name;
-            var arr = dirname.split(pathSep);
-            arr.push(name);
-            return _.compact(arr).join('.');
+            dirname += '.' + name;
+            return dirname.substring(1).replace(/\/|\\/g,'.');
         }();
         var mixinOutput = '';
         var template = beautify(jade.compile(fs.readFileSync(item, 'utf-8'), {


### PR DESCRIPTION
... issue #34 in main branch

Windows 7 having issues with templatizer.js adding forward slashes to the export path object for templates under subdirectories of the main clienttemplates directory. This appears to have fixed issue #34 for us as well, where mixins were not working, only under Windows.
