### PR TITLE
Use path.resolve instead of normalize to make it work on windows

### DIFF
--- a/templatizer.js
+++ b/templatizer.js
@@ -42,7 +42,7 @@ module.exports = function (templateDirectories, outputFile, dontTransformMixins)
         var contents = walkdir.sync(templateDirectory);
 
         contents.forEach(function (file) {
-            var item = file.replace(path.normalize(templateDirectory), '').slice(1);
+            var item = file.replace(path.resolve(templateDirectory), '').slice(1);
             if (path.extname(item) === '' && path.basename(item).charAt(0) !== '.') {
                 if (folders.indexOf(item) === -1) folders.push(item);
             } else if (path.extname(item) === '.jade') {


### PR DESCRIPTION
Using path.normalize doesn't turn relative paths into absolute, which is what is required by the code. I was running into this issue on windows, where it would attempt to use a path like this: 
`C:\git\aaaa\views\consumer\includes\templates\:\git\aaaa\bbbbb.jade`
