### PR TITLE
Fix issues with requirejs, cleanup runtime and built files

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -2,4 +2,5 @@ node_modules
 test/
 benchmark/icanhaz.js
 demo_output.js
-jaderuntime.min.js
+jaderuntime.js
+output_template.js

--- a/demo_output.js
+++ b/demo_output.js
@@ -1,487 +1,273 @@
-//jade runtime
-(function () {
-var exports; //work in browserify
-!function(e){if("object"==typeof exports)module.exports=e();else if("function"==typeof define&&define.amd)define(e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.jade=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
-'use strict';
-
-/**
- * Merge two attribute objects giving precedence
- * to values in object `b`. Classes are special-cased
- * allowing for arrays and merging/joining appropriately
- * resulting in a string.
- *
- * @param {Object} a
- * @param {Object} b
- * @return {Object} a
- * @api private
- */
-
-exports.merge = function merge(a, b) {
-  if (arguments.length === 1) {
-    var attrs = a[0];
-    for (var i = 1; i < a.length; i++) {
-      attrs = merge(attrs, a[i]);
-    }
-    return attrs;
-  }
-  var ac = a['class'];
-  var bc = b['class'];
-
-  if (ac || bc) {
-    ac = ac || [];
-    bc = bc || [];
-    if (!Array.isArray(ac)) ac = [ac];
-    if (!Array.isArray(bc)) bc = [bc];
-    a['class'] = ac.concat(bc).filter(nulls);
-  }
-
-  for (var key in b) {
-    if (key != 'class') {
-      a[key] = b[key];
-    }
-  }
-
-  return a;
-};
-
-/**
- * Filter null `val`s.
- *
- * @param {*} val
- * @return {Boolean}
- * @api private
- */
-
-function nulls(val) {
-  return val != null && val !== '';
-}
-
-/**
- * join array as classes.
- *
- * @param {*} val
- * @return {String}
- */
-exports.joinClasses = joinClasses;
-function joinClasses(val) {
-  return Array.isArray(val) ? val.map(joinClasses).filter(nulls).join(' ') : val;
-}
-
-/**
- * Render the given classes.
- *
- * @param {Array} classes
- * @param {Array.<Boolean>} escaped
- * @return {String}
- */
-exports.cls = function cls(classes, escaped) {
-  var buf = [];
-  for (var i = 0; i < classes.length; i++) {
-    if (escaped && escaped[i]) {
-      buf.push(exports.escape(joinClasses([classes[i]])));
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
     } else {
-      buf.push(joinClasses(classes[i]));
+        root.templatizer = factory();
     }
-  }
-  var text = joinClasses(buf);
-  if (text.length) {
-    return ' class="' + text + '"';
-  } else {
-    return '';
-  }
-};
+}(this, function () {
+    var jade=function(){function r(r){return null!=r&&""!==r}function n(e){return Array.isArray(e)?e.map(n).filter(r).join(" "):e}var e={};return e.merge=function t(n,e){if(1===arguments.length){for(var a=n[0],s=1;s<n.length;s++)a=t(a,n[s]);return a}var i=n["class"],l=e["class"];(i||l)&&(i=i||[],l=l||[],Array.isArray(i)||(i=[i]),Array.isArray(l)||(l=[l]),n["class"]=i.concat(l).filter(r));for(var o in e)"class"!=o&&(n[o]=e[o]);return n},e.joinClasses=n,e.cls=function(r,t){for(var a=[],s=0;s<r.length;s++)t&&t[s]?a.push(e.escape(n([r[s]]))):a.push(n(r[s]));var i=n(a);return i.length?' class="'+i+'"':""},e.attr=function(r,n,t,a){return"boolean"==typeof n||null==n?n?" "+(a?r:r+'="'+r+'"'):"":0==r.indexOf("data")&&"string"!=typeof n?" "+r+"='"+JSON.stringify(n).replace(/'/g,"&apos;")+"'":t?" "+r+'="'+e.escape(n)+'"':" "+r+'="'+n+'"'},e.attrs=function(r,t){var a=[],s=Object.keys(r);if(s.length)for(var i=0;i<s.length;++i){var l=s[i],o=r[l];"class"==l?(o=n(o))&&a.push(" "+l+'="'+o+'"'):a.push(e.attr(l,o,!1,t))}return a.join("")},e.escape=function(r){var n=String(r).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");return n===""+r?r:n},e.rethrow=function a(r,n,e,t){if(!(r instanceof Error))throw r;if(!("undefined"==typeof window&&n||t))throw r.message+=" on line "+e,r;try{t=t||require("fs").readFileSync(n,"utf8")}catch(s){a(r,null,e)}var i=3,l=t.split("\n"),o=Math.max(e-i,0),c=Math.min(l.length,e+i),i=l.slice(o,c).map(function(r,n){var t=n+o+1;return(t==e?"  > ":"    ")+t+"| "+r}).join("\n");throw r.path=n,r.message=(n||"Jade")+":"+e+"\n"+i+"\n\n"+r.message,r},e}();
 
-/**
- * Render the given attribute.
- *
- * @param {String} key
- * @param {String} val
- * @param {Boolean} escaped
- * @param {Boolean} terse
- * @return {String}
- */
-exports.attr = function attr(key, val, escaped, terse) {
-  if ('boolean' == typeof val || null == val) {
-    if (val) {
-      return ' ' + (terse ? key : key + '="' + key + '"');
-    } else {
-      return '';
-    }
-  } else if (0 == key.indexOf('data') && 'string' != typeof val) {
-    return ' ' + key + "='" + JSON.stringify(val).replace(/'/g, '&apos;') + "'";
-  } else if (escaped) {
-    return ' ' + key + '="' + exports.escape(val) + '"';
-  } else {
-    return ' ' + key + '="' + val + '"';
-  }
-};
+    var templatizer = {};
 
-/**
- * Render the given attributes object.
- *
- * @param {Object} obj
- * @param {Object} escaped
- * @return {String}
- */
-exports.attrs = function attrs(obj, terse){
-  var buf = [];
+    // create our folder objects
+    templatizer["otherfolder"] = {};
+    templatizer["otherfolder"]["deep2"] = {};
+    templatizer["otherfolder"]["deepnested"] = {};
 
-  var keys = Object.keys(obj);
+    // 404.jade compiled template
+    templatizer["404"] = function tmpl_404() {
+        return '<div class="page-404">404!</div>';
+    };
 
-  if (keys.length) {
-    for (var i = 0; i < keys.length; ++i) {
-      var key = keys[i]
-        , val = obj[key];
+    // 404withVars.jade compiled template
+    templatizer["404withVars"] = function tmpl_404withVars(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (content) {
+            buf.push('<div class="page-404">' + jade.escape((jade_interp = content || '404') == null ? '' : jade_interp) + '!</div>');
+        }('content' in locals_for_with ? locals_for_with.content : typeof content !== 'undefined' ? content : undefined));
+        return buf.join('');
+    };
 
-      if ('class' == key) {
-        if (val = joinClasses(val)) {
-          buf.push(' ' + key + '="' + val + '"');
-        }
-      } else {
-        buf.push(exports.attr(key, val, false, terse));
-      }
-    }
-  }
+    // otherfolder/deep2/deeptweet.jade compiled template
+    templatizer["otherfolder"]["deep2"]["deeptweet"] = function tmpl_otherfolder_deep2_deeptweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (tweet) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
+        }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
+        return buf.join('');
+    };
 
-  return buf.join('');
-};
+    // otherfolder/deepnested/deeptweet.jade compiled template
+    templatizer["otherfolder"]["deepnested"]["deeptweet"] = function tmpl_otherfolder_deepnested_deeptweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (tweet) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
+        }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
+        return buf.join('');
+    };
 
-/**
- * Escape the given string of `html`.
- *
- * @param {String} html
- * @return {String}
- * @api private
- */
-
-exports.escape = function escape(html){
-  var result = String(html)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-  if (result === '' + html) return html;
-  else return result;
-};
-
-/**
- * Re-throw the given `err` in context to the
- * the jade in `filename` at the given `lineno`.
- *
- * @param {Error} err
- * @param {String} filename
- * @param {String} lineno
- * @api private
- */
-
-exports.rethrow = function rethrow(err, filename, lineno, str){
-  if (!(err instanceof Error)) throw err;
-  if ((typeof window != 'undefined' || !filename) && !str) {
-    err.message += ' on line ' + lineno;
-    throw err;
-  }
-  try {
-    str =  str || _dereq_('fs').readFileSync(filename, 'utf8')
-  } catch (ex) {
-    rethrow(err, null, lineno)
-  }
-  var context = 3
-    , lines = str.split('\n')
-    , start = Math.max(lineno - context, 0)
-    , end = Math.min(lines.length, lineno + context);
-
-  // Error context
-  var context = lines.slice(start, end).map(function(line, i){
-    var curr = i + start + 1;
-    return (curr == lineno ? '  > ' : '    ')
-      + curr
-      + '| '
-      + line;
-  }).join('\n');
-
-  // Alter exception message
-  err.path = filename;
-  err.message = (filename || 'Jade') + ':' + lineno
-    + '\n' + context + '\n\n' + err.message;
-  throw err;
-};
-
-},{"fs":2}],2:[function(_dereq_,module,exports){
-
-},{}]},{},[1])
-(1)
-});
-})();
-
-(function () {
-var root = this, exports = {};
-
-// create our folder objects
-exports["otherfolder"] = {};
-exports["otherfolder"]["deep2"] = {};
-exports["otherfolder"]["deepnested"] = {};
-
-// 404.jade compiled template
-exports["404"] = function tmpl_404() {
-    return '<div class="page-404">404!</div>';
-};
-
-// 404withVars.jade compiled template
-exports["404withVars"] = function tmpl_404withVars(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (content) {
-        buf.push('<div class="page-404">' + jade.escape((jade_interp = content || '404') == null ? '' : jade_interp) + '!</div>');
-    }('content' in locals_for_with ? locals_for_with.content : typeof content !== 'undefined' ? content : undefined));
-    return buf.join('');
-};
-
-// otherfolder/deep2/deeptweet.jade compiled template
-exports["otherfolder"]["deep2"]["deeptweet"] = function tmpl_otherfolder_deep2_deeptweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (tweet) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
-    }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
-    return buf.join('');
-};
-
-// otherfolder/deepnested/deeptweet.jade compiled template
-exports["otherfolder"]["deepnested"]["deeptweet"] = function tmpl_otherfolder_deepnested_deeptweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (tweet) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
-    }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
-    return buf.join('');
-};
-
-// otherfolder/nestedMixin.jade compiled template
-exports["otherfolder"]["nestedMixin"] = function tmpl_otherfolder_nestedMixin(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        var i = 0;
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push(exports.otherfolder.nestedMixin.user_li(user, i));
-                    i++;
+    // otherfolder/nestedMixin.jade compiled template
+    templatizer["otherfolder"]["nestedMixin"] = function tmpl_otherfolder_nestedMixin(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            var i = 0;
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push(templatizer.otherfolder.nestedMixin.user_li(user, i));
+                        i++;
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push(templatizer.otherfolder.nestedMixin.user_li(user, i));
+                        i++;
+                    }
                 }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push(exports.otherfolder.nestedMixin.user_li(user, i));
-                    i++;
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
+
+    // otherfolder/nestedMixin.jade:user_li compiled template
+    templatizer["otherfolder"]["nestedMixin"]["user_li"] = function tmpl_otherfolder_nestedMixin_user_li(user, index) {
+        var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
+        buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + ">test</li>");
+        return buf.join("");
+    };
+
+    // otherfolder/othertweet.jade compiled template
+    templatizer["otherfolder"]["othertweet"] = function tmpl_otherfolder_othertweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (user) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = user) ? '' : jade_interp) + '</li>');
+        }('user' in locals_for_with ? locals_for_with.user : typeof user !== 'undefined' ? user : undefined));
+        return buf.join('');
+    };
+
+    // underscoreUsers.jade compiled template
+    templatizer["underscoreUsers"] = function tmpl_underscoreUsers(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users, _) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
+                    }
                 }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined, '_' in locals_for_with ? locals_for_with._ : typeof _ !== 'undefined' ? _ : undefined));
+        return buf.join('');
+    };
 
-// otherfolder/nestedMixin.jade:user_li compiled template
-exports["otherfolder"]["nestedMixin"]["user_li"] = function tmpl_otherfolder_nestedMixin_user_li(user, index) {
-    var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
-    buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + ">test</li>");
-    return buf.join("");
-};
+    // users.jade compiled template
+    templatizer["users"] = function tmpl_users(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
+                    }
+                }
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
 
-// otherfolder/othertweet.jade compiled template
-exports["otherfolder"]["othertweet"] = function tmpl_otherfolder_othertweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (user) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = user) ? '' : jade_interp) + '</li>');
-    }('user' in locals_for_with ? locals_for_with.user : typeof user !== 'undefined' ? user : undefined));
-    return buf.join('');
-};
-
-// underscoreUsers.jade compiled template
-exports["underscoreUsers"] = function tmpl_underscoreUsers(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users, _) {
+    // usersLocals.jade compiled template
+    templatizer["usersLocals"] = function tmpl_usersLocals(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
         buf.push('<ul>');
         (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
-                }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
-                }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined, '_' in locals_for_with ? locals_for_with._ : typeof _ !== 'undefined' ? _ : undefined));
-    return buf.join('');
-};
-
-// users.jade compiled template
-exports["users"] = function tmpl_users(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
+            var $obj = locals.users;
+            if ('number' == typeof $obj.length) {
+                for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                    var user = $obj[$index];
                     buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
                 }
             } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
+                var $l = 0;
+                for (var $index in $obj) {
+                    $l++;
+                    var user = $obj[$index];
                     buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
                 }
             }
         }.call(this));
         buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+        return buf.join('');
+    };
 
-// usersLocals.jade compiled template
-exports["usersLocals"] = function tmpl_usersLocals(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    buf.push('<ul>');
-    (function () {
-        var $$obj = locals.users;
-        if ('number' == typeof $$obj.length) {
-            for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                var user = $$obj[$index];
-                buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
-            }
-        } else {
-            var $$l = 0;
-            for (var $index in $$obj) {
-                $$l++;
-                var user = $$obj[$index];
-                buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
-            }
-        }
-    }.call(this));
-    buf.push('</ul>');
-    return buf.join('');
-};
-
-// usersMixins.jade compiled template
-exports["usersMixins"] = function tmpl_usersMixins(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        var i = 0;
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push(exports.usersMixins.user_li(user, i));
-                    i++;
+    // usersMixins.jade compiled template
+    templatizer["usersMixins"] = function tmpl_usersMixins(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            var i = 0;
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push(templatizer.usersMixins.user_li(user, i));
+                        i++;
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push(templatizer.usersMixins.user_li(user, i));
+                        i++;
+                    }
                 }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push(exports.usersMixins.user_li(user, i));
-                    i++;
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
+
+    // usersMixins.jade:user_li compiled template
+    templatizer["usersMixins"]["user_li"] = function tmpl_usersMixins_user_li(user, index) {
+        var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
+        buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + "><span>Before</span>");
+        buf.push(templatizer.usersMixins.user_a(user, index));
+        buf.push("</li>");
+        return buf.join("");
+    };
+
+    // usersMixins.jade:user_a compiled template
+    templatizer["usersMixins"]["user_a"] = function tmpl_usersMixins_user_a(user, index) {
+        var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
+        buf.push("<a" + jade.attr("href", user.url, true, false) + jade.attr("data-user-index", index, true, false) + ">Within " + jade.escape((jade_interp = user.name) == null ? "" : jade_interp) + "</a>");
+        return buf.join("");
+    };
+
+    // userscomplex.jade compiled template
+    templatizer["userscomplex"] = function tmpl_userscomplex(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
+                    }
                 }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
 
-// usersMixins.jade:user_li compiled template
-exports["usersMixins"]["user_li"] = function tmpl_usersMixins_user_li(user, index) {
-    var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
-    buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + "><span>Before</span>");
-    buf.push(exports.usersMixins.user_a(user, index));
-    buf.push("</li>");
-    return buf.join("");
-};
-
-// usersMixins.jade:user_a compiled template
-exports["usersMixins"]["user_a"] = function tmpl_usersMixins_user_a(user, index) {
-    var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
-    buf.push("<a" + jade.attr("href", user.url, true, false) + jade.attr("data-user-index", index, true, false) + ">Within " + jade.escape((jade_interp = user.name) == null ? "" : jade_interp) + "</a>");
-    return buf.join("");
-};
-
-// userscomplex.jade compiled template
-exports["userscomplex"] = function tmpl_userscomplex(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
-                }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
-                }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
-
-
-// attach to window or export with commonJS
-if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
-    module.exports = exports;
-} else if (typeof define === "function" && define.amd) {
-    define(exports);
-} else {
-    root.templatizer = exports;
-}
-
-})();
+    return templatizer;
+}));

--- a/jaderuntime.js
+++ b/jaderuntime.js
@@ -1,4 +1,3 @@
-!function(e){if("object"==typeof exports)module.exports=e();else if("function"==typeof define&&define.amd)define(e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.jade=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
 /**
@@ -202,9 +201,3 @@ exports.rethrow = function rethrow(err, filename, lineno, str){
     + '\n' + context + '\n\n' + err.message;
   throw err;
 };
-
-},{"fs":2}],2:[function(require,module,exports){
-
-},{}]},{},[1])
-(1)
-});

--- a/output_template.js
+++ b/output_template.js
@@ -1,0 +1,15 @@
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
+    } else {
+        root.templatizer = factory();
+    }
+}(this, function () {
+    {{jade}}
+
+    var templatizer = {};
+{{code}}
+    return templatizer;
+}));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "templatizer",
   "description": "Simple solution for compiling jade templates into vanilla JS functions for blazin' fast client-side use.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "bugs": "https://github.com/HenrikJoreteg/templatizer/issues",
   "contributors": [
@@ -42,9 +42,10 @@
     "url": "https://github.com/HenrikJoreteg/templatizer.git"
   },
   "scripts": {
+    "runtime": "cp node_modules/jade/lib/runtime.js jaderuntime.js",
     "benchmark": "node benchmark/speedtest.js",
-    "builddemo": "node benchmark/build-demo.js",
+    "build": "npm run runtime && node benchmark/build-demo.js",
     "browserify": "./node_modules/.bin/browserify test/browserify-test.js > test/tests-bundle.js",
-    "test": "npm run builddemo && npm run browserify && open ./test/index.html  && open ./test/browserify.html"
+    "test": "npm run build && npm run browserify && open ./test/index.html  && open ./test/browserify.html"
   }
 }

--- a/test/demo_output_multiple_dirs.js
+++ b/test/demo_output_multiple_dirs.js
@@ -1,497 +1,283 @@
-//jade runtime
-(function () {
-var exports; //work in browserify
-!function(e){if("object"==typeof exports)module.exports=e();else if("function"==typeof define&&define.amd)define(e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.jade=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
-'use strict';
-
-/**
- * Merge two attribute objects giving precedence
- * to values in object `b`. Classes are special-cased
- * allowing for arrays and merging/joining appropriately
- * resulting in a string.
- *
- * @param {Object} a
- * @param {Object} b
- * @return {Object} a
- * @api private
- */
-
-exports.merge = function merge(a, b) {
-  if (arguments.length === 1) {
-    var attrs = a[0];
-    for (var i = 1; i < a.length; i++) {
-      attrs = merge(attrs, a[i]);
-    }
-    return attrs;
-  }
-  var ac = a['class'];
-  var bc = b['class'];
-
-  if (ac || bc) {
-    ac = ac || [];
-    bc = bc || [];
-    if (!Array.isArray(ac)) ac = [ac];
-    if (!Array.isArray(bc)) bc = [bc];
-    a['class'] = ac.concat(bc).filter(nulls);
-  }
-
-  for (var key in b) {
-    if (key != 'class') {
-      a[key] = b[key];
-    }
-  }
-
-  return a;
-};
-
-/**
- * Filter null `val`s.
- *
- * @param {*} val
- * @return {Boolean}
- * @api private
- */
-
-function nulls(val) {
-  return val != null && val !== '';
-}
-
-/**
- * join array as classes.
- *
- * @param {*} val
- * @return {String}
- */
-exports.joinClasses = joinClasses;
-function joinClasses(val) {
-  return Array.isArray(val) ? val.map(joinClasses).filter(nulls).join(' ') : val;
-}
-
-/**
- * Render the given classes.
- *
- * @param {Array} classes
- * @param {Array.<Boolean>} escaped
- * @return {String}
- */
-exports.cls = function cls(classes, escaped) {
-  var buf = [];
-  for (var i = 0; i < classes.length; i++) {
-    if (escaped && escaped[i]) {
-      buf.push(exports.escape(joinClasses([classes[i]])));
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
     } else {
-      buf.push(joinClasses(classes[i]));
+        root.templatizer = factory();
     }
-  }
-  var text = joinClasses(buf);
-  if (text.length) {
-    return ' class="' + text + '"';
-  } else {
-    return '';
-  }
-};
+}(this, function () {
+    var jade=function(){function r(r){return null!=r&&""!==r}function n(e){return Array.isArray(e)?e.map(n).filter(r).join(" "):e}var e={};return e.merge=function t(n,e){if(1===arguments.length){for(var a=n[0],s=1;s<n.length;s++)a=t(a,n[s]);return a}var i=n["class"],l=e["class"];(i||l)&&(i=i||[],l=l||[],Array.isArray(i)||(i=[i]),Array.isArray(l)||(l=[l]),n["class"]=i.concat(l).filter(r));for(var o in e)"class"!=o&&(n[o]=e[o]);return n},e.joinClasses=n,e.cls=function(r,t){for(var a=[],s=0;s<r.length;s++)t&&t[s]?a.push(e.escape(n([r[s]]))):a.push(n(r[s]));var i=n(a);return i.length?' class="'+i+'"':""},e.attr=function(r,n,t,a){return"boolean"==typeof n||null==n?n?" "+(a?r:r+'="'+r+'"'):"":0==r.indexOf("data")&&"string"!=typeof n?" "+r+"='"+JSON.stringify(n).replace(/'/g,"&apos;")+"'":t?" "+r+'="'+e.escape(n)+'"':" "+r+'="'+n+'"'},e.attrs=function(r,t){var a=[],s=Object.keys(r);if(s.length)for(var i=0;i<s.length;++i){var l=s[i],o=r[l];"class"==l?(o=n(o))&&a.push(" "+l+'="'+o+'"'):a.push(e.attr(l,o,!1,t))}return a.join("")},e.escape=function(r){var n=String(r).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");return n===""+r?r:n},e.rethrow=function a(r,n,e,t){if(!(r instanceof Error))throw r;if(!("undefined"==typeof window&&n||t))throw r.message+=" on line "+e,r;try{t=t||require("fs").readFileSync(n,"utf8")}catch(s){a(r,null,e)}var i=3,l=t.split("\n"),o=Math.max(e-i,0),c=Math.min(l.length,e+i),i=l.slice(o,c).map(function(r,n){var t=n+o+1;return(t==e?"  > ":"    ")+t+"| "+r}).join("\n");throw r.path=n,r.message=(n||"Jade")+":"+e+"\n"+i+"\n\n"+r.message,r},e}();
 
-/**
- * Render the given attribute.
- *
- * @param {String} key
- * @param {String} val
- * @param {Boolean} escaped
- * @param {Boolean} terse
- * @return {String}
- */
-exports.attr = function attr(key, val, escaped, terse) {
-  if ('boolean' == typeof val || null == val) {
-    if (val) {
-      return ' ' + (terse ? key : key + '="' + key + '"');
-    } else {
-      return '';
-    }
-  } else if (0 == key.indexOf('data') && 'string' != typeof val) {
-    return ' ' + key + "='" + JSON.stringify(val).replace(/'/g, '&apos;') + "'";
-  } else if (escaped) {
-    return ' ' + key + '="' + exports.escape(val) + '"';
-  } else {
-    return ' ' + key + '="' + val + '"';
-  }
-};
+    var templatizer = {};
 
-/**
- * Render the given attributes object.
- *
- * @param {Object} obj
- * @param {Object} escaped
- * @return {String}
- */
-exports.attrs = function attrs(obj, terse){
-  var buf = [];
+    // create our folder objects
+    templatizer["otherfolder"] = {};
+    templatizer["otherfolder"]["deep2"] = {};
+    templatizer["otherfolder"]["deepnested"] = {};
 
-  var keys = Object.keys(obj);
+    // 404.jade compiled template
+    templatizer["404"] = function tmpl_404() {
+        return '<div class="page-404">404!</div>';
+    };
 
-  if (keys.length) {
-    for (var i = 0; i < keys.length; ++i) {
-      var key = keys[i]
-        , val = obj[key];
+    // 404withVars.jade compiled template
+    templatizer["404withVars"] = function tmpl_404withVars(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (content) {
+            buf.push('<div class="page-404">' + jade.escape((jade_interp = content || '404') == null ? '' : jade_interp) + '!</div>');
+        }('content' in locals_for_with ? locals_for_with.content : typeof content !== 'undefined' ? content : undefined));
+        return buf.join('');
+    };
 
-      if ('class' == key) {
-        if (val = joinClasses(val)) {
-          buf.push(' ' + key + '="' + val + '"');
-        }
-      } else {
-        buf.push(exports.attr(key, val, false, terse));
-      }
-    }
-  }
+    // otherfolder/deep2/deeptweet.jade compiled template
+    templatizer["otherfolder"]["deep2"]["deeptweet"] = function tmpl_otherfolder_deep2_deeptweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (tweet) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
+        }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
+        return buf.join('');
+    };
 
-  return buf.join('');
-};
+    // otherfolder/deepnested/deeptweet.jade compiled template
+    templatizer["otherfolder"]["deepnested"]["deeptweet"] = function tmpl_otherfolder_deepnested_deeptweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (tweet) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
+        }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
+        return buf.join('');
+    };
 
-/**
- * Escape the given string of `html`.
- *
- * @param {String} html
- * @return {String}
- * @api private
- */
-
-exports.escape = function escape(html){
-  var result = String(html)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-  if (result === '' + html) return html;
-  else return result;
-};
-
-/**
- * Re-throw the given `err` in context to the
- * the jade in `filename` at the given `lineno`.
- *
- * @param {Error} err
- * @param {String} filename
- * @param {String} lineno
- * @api private
- */
-
-exports.rethrow = function rethrow(err, filename, lineno, str){
-  if (!(err instanceof Error)) throw err;
-  if ((typeof window != 'undefined' || !filename) && !str) {
-    err.message += ' on line ' + lineno;
-    throw err;
-  }
-  try {
-    str =  str || _dereq_('fs').readFileSync(filename, 'utf8')
-  } catch (ex) {
-    rethrow(err, null, lineno)
-  }
-  var context = 3
-    , lines = str.split('\n')
-    , start = Math.max(lineno - context, 0)
-    , end = Math.min(lines.length, lineno + context);
-
-  // Error context
-  var context = lines.slice(start, end).map(function(line, i){
-    var curr = i + start + 1;
-    return (curr == lineno ? '  > ' : '    ')
-      + curr
-      + '| '
-      + line;
-  }).join('\n');
-
-  // Alter exception message
-  err.path = filename;
-  err.message = (filename || 'Jade') + ':' + lineno
-    + '\n' + context + '\n\n' + err.message;
-  throw err;
-};
-
-},{"fs":2}],2:[function(_dereq_,module,exports){
-
-},{}]},{},[1])
-(1)
-});
-})();
-
-(function () {
-var root = this, exports = {};
-
-// create our folder objects
-exports["otherfolder"] = {};
-exports["otherfolder"]["deep2"] = {};
-exports["otherfolder"]["deepnested"] = {};
-
-// 404.jade compiled template
-exports["404"] = function tmpl_404() {
-    return '<div class="page-404">404!</div>';
-};
-
-// 404withVars.jade compiled template
-exports["404withVars"] = function tmpl_404withVars(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (content) {
-        buf.push('<div class="page-404">' + jade.escape((jade_interp = content || '404') == null ? '' : jade_interp) + '!</div>');
-    }('content' in locals_for_with ? locals_for_with.content : typeof content !== 'undefined' ? content : undefined));
-    return buf.join('');
-};
-
-// otherfolder/deep2/deeptweet.jade compiled template
-exports["otherfolder"]["deep2"]["deeptweet"] = function tmpl_otherfolder_deep2_deeptweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (tweet) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
-    }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
-    return buf.join('');
-};
-
-// otherfolder/deepnested/deeptweet.jade compiled template
-exports["otherfolder"]["deepnested"]["deeptweet"] = function tmpl_otherfolder_deepnested_deeptweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (tweet) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
-    }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
-    return buf.join('');
-};
-
-// otherfolder/nestedMixin.jade compiled template
-exports["otherfolder"]["nestedMixin"] = function tmpl_otherfolder_nestedMixin(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        var i = 0;
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push(exports.otherfolder.nestedMixin.user_li(user, i));
-                    i++;
+    // otherfolder/nestedMixin.jade compiled template
+    templatizer["otherfolder"]["nestedMixin"] = function tmpl_otherfolder_nestedMixin(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            var i = 0;
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push(templatizer.otherfolder.nestedMixin.user_li(user, i));
+                        i++;
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push(templatizer.otherfolder.nestedMixin.user_li(user, i));
+                        i++;
+                    }
                 }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push(exports.otherfolder.nestedMixin.user_li(user, i));
-                    i++;
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
+
+    // otherfolder/nestedMixin.jade:user_li compiled template
+    templatizer["otherfolder"]["nestedMixin"]["user_li"] = function tmpl_otherfolder_nestedMixin_user_li(user, index) {
+        var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
+        buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + ">test</li>");
+        return buf.join("");
+    };
+
+    // otherfolder/othertweet.jade compiled template
+    templatizer["otherfolder"]["othertweet"] = function tmpl_otherfolder_othertweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (user) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = user) ? '' : jade_interp) + '</li>');
+        }('user' in locals_for_with ? locals_for_with.user : typeof user !== 'undefined' ? user : undefined));
+        return buf.join('');
+    };
+
+    // underscoreUsers.jade compiled template
+    templatizer["underscoreUsers"] = function tmpl_underscoreUsers(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users, _) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
+                    }
                 }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined, '_' in locals_for_with ? locals_for_with._ : typeof _ !== 'undefined' ? _ : undefined));
+        return buf.join('');
+    };
 
-// otherfolder/nestedMixin.jade:user_li compiled template
-exports["otherfolder"]["nestedMixin"]["user_li"] = function tmpl_otherfolder_nestedMixin_user_li(user, index) {
-    var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
-    buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + ">test</li>");
-    return buf.join("");
-};
+    // users.jade compiled template
+    templatizer["users"] = function tmpl_users(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
+                    }
+                }
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
 
-// otherfolder/othertweet.jade compiled template
-exports["otherfolder"]["othertweet"] = function tmpl_otherfolder_othertweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (user) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = user) ? '' : jade_interp) + '</li>');
-    }('user' in locals_for_with ? locals_for_with.user : typeof user !== 'undefined' ? user : undefined));
-    return buf.join('');
-};
-
-// underscoreUsers.jade compiled template
-exports["underscoreUsers"] = function tmpl_underscoreUsers(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users, _) {
+    // usersLocals.jade compiled template
+    templatizer["usersLocals"] = function tmpl_usersLocals(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
         buf.push('<ul>');
         (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
-                }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
-                }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined, '_' in locals_for_with ? locals_for_with._ : typeof _ !== 'undefined' ? _ : undefined));
-    return buf.join('');
-};
-
-// users.jade compiled template
-exports["users"] = function tmpl_users(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
+            var $obj = locals.users;
+            if ('number' == typeof $obj.length) {
+                for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                    var user = $obj[$index];
                     buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
                 }
             } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
+                var $l = 0;
+                for (var $index in $obj) {
+                    $l++;
+                    var user = $obj[$index];
                     buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
                 }
             }
         }.call(this));
         buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+        return buf.join('');
+    };
 
-// usersLocals.jade compiled template
-exports["usersLocals"] = function tmpl_usersLocals(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    buf.push('<ul>');
-    (function () {
-        var $$obj = locals.users;
-        if ('number' == typeof $$obj.length) {
-            for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                var user = $$obj[$index];
-                buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
-            }
-        } else {
-            var $$l = 0;
-            for (var $index in $$obj) {
-                $$l++;
-                var user = $$obj[$index];
-                buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
-            }
-        }
-    }.call(this));
-    buf.push('</ul>');
-    return buf.join('');
-};
-
-// usersMixins.jade compiled template
-exports["usersMixins"] = function tmpl_usersMixins(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        var i = 0;
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push(exports.usersMixins.user_li(user, i));
-                    i++;
+    // usersMixins.jade compiled template
+    templatizer["usersMixins"] = function tmpl_usersMixins(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            var i = 0;
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push(templatizer.usersMixins.user_li(user, i));
+                        i++;
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push(templatizer.usersMixins.user_li(user, i));
+                        i++;
+                    }
                 }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push(exports.usersMixins.user_li(user, i));
-                    i++;
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
+
+    // usersMixins.jade:user_li compiled template
+    templatizer["usersMixins"]["user_li"] = function tmpl_usersMixins_user_li(user, index) {
+        var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
+        buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + "><span>Before</span>");
+        buf.push(templatizer.usersMixins.user_a(user, index));
+        buf.push("</li>");
+        return buf.join("");
+    };
+
+    // usersMixins.jade:user_a compiled template
+    templatizer["usersMixins"]["user_a"] = function tmpl_usersMixins_user_a(user, index) {
+        var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
+        buf.push("<a" + jade.attr("href", user.url, true, false) + jade.attr("data-user-index", index, true, false) + ">Within " + jade.escape((jade_interp = user.name) == null ? "" : jade_interp) + "</a>");
+        return buf.join("");
+    };
+
+    // userscomplex.jade compiled template
+    templatizer["userscomplex"] = function tmpl_userscomplex(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
+                    }
                 }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
 
-// usersMixins.jade:user_li compiled template
-exports["usersMixins"]["user_li"] = function tmpl_usersMixins_user_li(user, index) {
-    var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
-    buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + "><span>Before</span>");
-    buf.push(exports.usersMixins.user_a(user, index));
-    buf.push("</li>");
-    return buf.join("");
-};
+    // otherfolder/othertweet2.jade compiled template
+    templatizer["otherfolder"]["othertweet2"] = function tmpl_otherfolder_othertweet2() {
+        return '<p>test</p>';
+    };
 
-// usersMixins.jade:user_a compiled template
-exports["usersMixins"]["user_a"] = function tmpl_usersMixins_user_a(user, index) {
-    var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
-    buf.push("<a" + jade.attr("href", user.url, true, false) + jade.attr("data-user-index", index, true, false) + ">Within " + jade.escape((jade_interp = user.name) == null ? "" : jade_interp) + "</a>");
-    return buf.join("");
-};
+    // test.jade compiled template
+    templatizer["test"] = function tmpl_test() {
+        return '<p>test</p>';
+    };
 
-// userscomplex.jade compiled template
-exports["userscomplex"] = function tmpl_userscomplex(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
-                }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
-                }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
-
-// otherfolder/othertweet2.jade compiled template
-exports["otherfolder"]["othertweet2"] = function tmpl_otherfolder_othertweet2() {
-    return '<p>test</p>';
-};
-
-// test.jade compiled template
-exports["test"] = function tmpl_test() {
-    return '<p>test</p>';
-};
-
-
-// attach to window or export with commonJS
-if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
-    module.exports = exports;
-} else if (typeof define === "function" && define.amd) {
-    define(exports);
-} else {
-    root.templatizer = exports;
-}
-
-})();
+    return templatizer;
+}));

--- a/test/demo_output_no_mixins.js
+++ b/test/demo_output_no_mixins.js
@@ -1,478 +1,264 @@
-//jade runtime
-(function () {
-var exports; //work in browserify
-!function(e){if("object"==typeof exports)module.exports=e();else if("function"==typeof define&&define.amd)define(e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.jade=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
-'use strict';
-
-/**
- * Merge two attribute objects giving precedence
- * to values in object `b`. Classes are special-cased
- * allowing for arrays and merging/joining appropriately
- * resulting in a string.
- *
- * @param {Object} a
- * @param {Object} b
- * @return {Object} a
- * @api private
- */
-
-exports.merge = function merge(a, b) {
-  if (arguments.length === 1) {
-    var attrs = a[0];
-    for (var i = 1; i < a.length; i++) {
-      attrs = merge(attrs, a[i]);
-    }
-    return attrs;
-  }
-  var ac = a['class'];
-  var bc = b['class'];
-
-  if (ac || bc) {
-    ac = ac || [];
-    bc = bc || [];
-    if (!Array.isArray(ac)) ac = [ac];
-    if (!Array.isArray(bc)) bc = [bc];
-    a['class'] = ac.concat(bc).filter(nulls);
-  }
-
-  for (var key in b) {
-    if (key != 'class') {
-      a[key] = b[key];
-    }
-  }
-
-  return a;
-};
-
-/**
- * Filter null `val`s.
- *
- * @param {*} val
- * @return {Boolean}
- * @api private
- */
-
-function nulls(val) {
-  return val != null && val !== '';
-}
-
-/**
- * join array as classes.
- *
- * @param {*} val
- * @return {String}
- */
-exports.joinClasses = joinClasses;
-function joinClasses(val) {
-  return Array.isArray(val) ? val.map(joinClasses).filter(nulls).join(' ') : val;
-}
-
-/**
- * Render the given classes.
- *
- * @param {Array} classes
- * @param {Array.<Boolean>} escaped
- * @return {String}
- */
-exports.cls = function cls(classes, escaped) {
-  var buf = [];
-  for (var i = 0; i < classes.length; i++) {
-    if (escaped && escaped[i]) {
-      buf.push(exports.escape(joinClasses([classes[i]])));
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
     } else {
-      buf.push(joinClasses(classes[i]));
+        root.templatizer = factory();
     }
-  }
-  var text = joinClasses(buf);
-  if (text.length) {
-    return ' class="' + text + '"';
-  } else {
-    return '';
-  }
-};
+}(this, function () {
+    var jade=function(){function r(r){return null!=r&&""!==r}function n(e){return Array.isArray(e)?e.map(n).filter(r).join(" "):e}var e={};return e.merge=function t(n,e){if(1===arguments.length){for(var a=n[0],s=1;s<n.length;s++)a=t(a,n[s]);return a}var i=n["class"],l=e["class"];(i||l)&&(i=i||[],l=l||[],Array.isArray(i)||(i=[i]),Array.isArray(l)||(l=[l]),n["class"]=i.concat(l).filter(r));for(var o in e)"class"!=o&&(n[o]=e[o]);return n},e.joinClasses=n,e.cls=function(r,t){for(var a=[],s=0;s<r.length;s++)t&&t[s]?a.push(e.escape(n([r[s]]))):a.push(n(r[s]));var i=n(a);return i.length?' class="'+i+'"':""},e.attr=function(r,n,t,a){return"boolean"==typeof n||null==n?n?" "+(a?r:r+'="'+r+'"'):"":0==r.indexOf("data")&&"string"!=typeof n?" "+r+"='"+JSON.stringify(n).replace(/'/g,"&apos;")+"'":t?" "+r+'="'+e.escape(n)+'"':" "+r+'="'+n+'"'},e.attrs=function(r,t){var a=[],s=Object.keys(r);if(s.length)for(var i=0;i<s.length;++i){var l=s[i],o=r[l];"class"==l?(o=n(o))&&a.push(" "+l+'="'+o+'"'):a.push(e.attr(l,o,!1,t))}return a.join("")},e.escape=function(r){var n=String(r).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");return n===""+r?r:n},e.rethrow=function a(r,n,e,t){if(!(r instanceof Error))throw r;if(!("undefined"==typeof window&&n||t))throw r.message+=" on line "+e,r;try{t=t||require("fs").readFileSync(n,"utf8")}catch(s){a(r,null,e)}var i=3,l=t.split("\n"),o=Math.max(e-i,0),c=Math.min(l.length,e+i),i=l.slice(o,c).map(function(r,n){var t=n+o+1;return(t==e?"  > ":"    ")+t+"| "+r}).join("\n");throw r.path=n,r.message=(n||"Jade")+":"+e+"\n"+i+"\n\n"+r.message,r},e}();
 
-/**
- * Render the given attribute.
- *
- * @param {String} key
- * @param {String} val
- * @param {Boolean} escaped
- * @param {Boolean} terse
- * @return {String}
- */
-exports.attr = function attr(key, val, escaped, terse) {
-  if ('boolean' == typeof val || null == val) {
-    if (val) {
-      return ' ' + (terse ? key : key + '="' + key + '"');
-    } else {
-      return '';
-    }
-  } else if (0 == key.indexOf('data') && 'string' != typeof val) {
-    return ' ' + key + "='" + JSON.stringify(val).replace(/'/g, '&apos;') + "'";
-  } else if (escaped) {
-    return ' ' + key + '="' + exports.escape(val) + '"';
-  } else {
-    return ' ' + key + '="' + val + '"';
-  }
-};
+    var templatizer = {};
 
-/**
- * Render the given attributes object.
- *
- * @param {Object} obj
- * @param {Object} escaped
- * @return {String}
- */
-exports.attrs = function attrs(obj, terse){
-  var buf = [];
+    // create our folder objects
+    templatizer["otherfolder"] = {};
+    templatizer["otherfolder"]["deep2"] = {};
+    templatizer["otherfolder"]["deepnested"] = {};
 
-  var keys = Object.keys(obj);
+    // 404.jade compiled template
+    templatizer["404"] = function tmpl_404() {
+        return '<div class="page-404">404!</div>';
+    };
 
-  if (keys.length) {
-    for (var i = 0; i < keys.length; ++i) {
-      var key = keys[i]
-        , val = obj[key];
+    // 404withVars.jade compiled template
+    templatizer["404withVars"] = function tmpl_404withVars(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (content) {
+            buf.push('<div class="page-404">' + jade.escape((jade_interp = content || '404') == null ? '' : jade_interp) + '!</div>');
+        }('content' in locals_for_with ? locals_for_with.content : typeof content !== 'undefined' ? content : undefined));
+        return buf.join('');
+    };
 
-      if ('class' == key) {
-        if (val = joinClasses(val)) {
-          buf.push(' ' + key + '="' + val + '"');
-        }
-      } else {
-        buf.push(exports.attr(key, val, false, terse));
-      }
-    }
-  }
+    // otherfolder/deep2/deeptweet.jade compiled template
+    templatizer["otherfolder"]["deep2"]["deeptweet"] = function tmpl_otherfolder_deep2_deeptweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (tweet) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
+        }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
+        return buf.join('');
+    };
 
-  return buf.join('');
-};
+    // otherfolder/deepnested/deeptweet.jade compiled template
+    templatizer["otherfolder"]["deepnested"]["deeptweet"] = function tmpl_otherfolder_deepnested_deeptweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (tweet) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
+        }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
+        return buf.join('');
+    };
 
-/**
- * Escape the given string of `html`.
- *
- * @param {String} html
- * @return {String}
- * @api private
- */
-
-exports.escape = function escape(html){
-  var result = String(html)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-  if (result === '' + html) return html;
-  else return result;
-};
-
-/**
- * Re-throw the given `err` in context to the
- * the jade in `filename` at the given `lineno`.
- *
- * @param {Error} err
- * @param {String} filename
- * @param {String} lineno
- * @api private
- */
-
-exports.rethrow = function rethrow(err, filename, lineno, str){
-  if (!(err instanceof Error)) throw err;
-  if ((typeof window != 'undefined' || !filename) && !str) {
-    err.message += ' on line ' + lineno;
-    throw err;
-  }
-  try {
-    str =  str || _dereq_('fs').readFileSync(filename, 'utf8')
-  } catch (ex) {
-    rethrow(err, null, lineno)
-  }
-  var context = 3
-    , lines = str.split('\n')
-    , start = Math.max(lineno - context, 0)
-    , end = Math.min(lines.length, lineno + context);
-
-  // Error context
-  var context = lines.slice(start, end).map(function(line, i){
-    var curr = i + start + 1;
-    return (curr == lineno ? '  > ' : '    ')
-      + curr
-      + '| '
-      + line;
-  }).join('\n');
-
-  // Alter exception message
-  err.path = filename;
-  err.message = (filename || 'Jade') + ':' + lineno
-    + '\n' + context + '\n\n' + err.message;
-  throw err;
-};
-
-},{"fs":2}],2:[function(_dereq_,module,exports){
-
-},{}]},{},[1])
-(1)
-});
-})();
-
-(function () {
-var root = this, exports = {};
-
-// create our folder objects
-exports["otherfolder"] = {};
-exports["otherfolder"]["deep2"] = {};
-exports["otherfolder"]["deepnested"] = {};
-
-// 404.jade compiled template
-exports["404"] = function tmpl_404() {
-    return '<div class="page-404">404!</div>';
-};
-
-// 404withVars.jade compiled template
-exports["404withVars"] = function tmpl_404withVars(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (content) {
-        buf.push('<div class="page-404">' + jade.escape((jade_interp = content || '404') == null ? '' : jade_interp) + '!</div>');
-    }('content' in locals_for_with ? locals_for_with.content : typeof content !== 'undefined' ? content : undefined));
-    return buf.join('');
-};
-
-// otherfolder/deep2/deeptweet.jade compiled template
-exports["otherfolder"]["deep2"]["deeptweet"] = function tmpl_otherfolder_deep2_deeptweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (tweet) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
-    }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
-    return buf.join('');
-};
-
-// otherfolder/deepnested/deeptweet.jade compiled template
-exports["otherfolder"]["deepnested"]["deeptweet"] = function tmpl_otherfolder_deepnested_deeptweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (tweet) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
-    }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
-    return buf.join('');
-};
-
-// otherfolder/nestedMixin.jade compiled template
-exports["otherfolder"]["nestedMixin"] = function tmpl_otherfolder_nestedMixin(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        jade_mixins['user_li'] = function (user, index) {
-            var block = this && this.block, attributes = this && this.attributes || {};
-            buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + jade.attr('data-user-index', index, true, false) + '>test</li>');
-        };
-        buf.push('<ul>');
-        var i = 0;
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    jade_mixins['user_li'](user, i);
-                    i++;
+    // otherfolder/nestedMixin.jade compiled template
+    templatizer["otherfolder"]["nestedMixin"] = function tmpl_otherfolder_nestedMixin(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            jade_mixins['user_li'] = function (user, index) {
+                var block = this && this.block, attributes = this && this.attributes || {};
+                buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + jade.attr('data-user-index', index, true, false) + '>test</li>');
+            };
+            buf.push('<ul>');
+            var i = 0;
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        jade_mixins['user_li'](user, i);
+                        i++;
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        jade_mixins['user_li'](user, i);
+                        i++;
+                    }
                 }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    jade_mixins['user_li'](user, i);
-                    i++;
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
+
+    // otherfolder/othertweet.jade compiled template
+    templatizer["otherfolder"]["othertweet"] = function tmpl_otherfolder_othertweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (user) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = user) ? '' : jade_interp) + '</li>');
+        }('user' in locals_for_with ? locals_for_with.user : typeof user !== 'undefined' ? user : undefined));
+        return buf.join('');
+    };
+
+    // underscoreUsers.jade compiled template
+    templatizer["underscoreUsers"] = function tmpl_underscoreUsers(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users, _) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
+                    }
                 }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined, '_' in locals_for_with ? locals_for_with._ : typeof _ !== 'undefined' ? _ : undefined));
+        return buf.join('');
+    };
 
-// otherfolder/othertweet.jade compiled template
-exports["otherfolder"]["othertweet"] = function tmpl_otherfolder_othertweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (user) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = user) ? '' : jade_interp) + '</li>');
-    }('user' in locals_for_with ? locals_for_with.user : typeof user !== 'undefined' ? user : undefined));
-    return buf.join('');
-};
+    // users.jade compiled template
+    templatizer["users"] = function tmpl_users(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
+                    }
+                }
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
 
-// underscoreUsers.jade compiled template
-exports["underscoreUsers"] = function tmpl_underscoreUsers(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users, _) {
+    // usersLocals.jade compiled template
+    templatizer["usersLocals"] = function tmpl_usersLocals(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
         buf.push('<ul>');
         (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
-                }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
-                }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined, '_' in locals_for_with ? locals_for_with._ : typeof _ !== 'undefined' ? _ : undefined));
-    return buf.join('');
-};
-
-// users.jade compiled template
-exports["users"] = function tmpl_users(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
+            var $obj = locals.users;
+            if ('number' == typeof $obj.length) {
+                for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                    var user = $obj[$index];
                     buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
                 }
             } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
+                var $l = 0;
+                for (var $index in $obj) {
+                    $l++;
+                    var user = $obj[$index];
                     buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
                 }
             }
         }.call(this));
         buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+        return buf.join('');
+    };
 
-// usersLocals.jade compiled template
-exports["usersLocals"] = function tmpl_usersLocals(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    buf.push('<ul>');
-    (function () {
-        var $$obj = locals.users;
-        if ('number' == typeof $$obj.length) {
-            for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                var user = $$obj[$index];
-                buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
-            }
-        } else {
-            var $$l = 0;
-            for (var $index in $$obj) {
-                $$l++;
-                var user = $$obj[$index];
-                buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
-            }
-        }
-    }.call(this));
-    buf.push('</ul>');
-    return buf.join('');
-};
-
-// usersMixins.jade compiled template
-exports["usersMixins"] = function tmpl_usersMixins(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        jade_mixins['user_li'] = function (user, index) {
-            var block = this && this.block, attributes = this && this.attributes || {};
-            buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + jade.attr('data-user-index', index, true, false) + '><span>Before</span>');
-            jade_mixins['user_a'](user, index);
-            buf.push('</li>');
-        };
-        jade_mixins['user_a'] = function (user, index) {
-            var block = this && this.block, attributes = this && this.attributes || {};
-            buf.push('<a' + jade.attr('href', user.url, true, false) + jade.attr('data-user-index', index, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a>');
-        };
-        buf.push('<ul>');
-        var i = 0;
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    jade_mixins['user_li'](user, i);
-                    i++;
+    // usersMixins.jade compiled template
+    templatizer["usersMixins"] = function tmpl_usersMixins(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            jade_mixins['user_li'] = function (user, index) {
+                var block = this && this.block, attributes = this && this.attributes || {};
+                buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + jade.attr('data-user-index', index, true, false) + '><span>Before</span>');
+                jade_mixins['user_a'](user, index);
+                buf.push('</li>');
+            };
+            jade_mixins['user_a'] = function (user, index) {
+                var block = this && this.block, attributes = this && this.attributes || {};
+                buf.push('<a' + jade.attr('href', user.url, true, false) + jade.attr('data-user-index', index, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a>');
+            };
+            buf.push('<ul>');
+            var i = 0;
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        jade_mixins['user_li'](user, i);
+                        i++;
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        jade_mixins['user_li'](user, i);
+                        i++;
+                    }
                 }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    jade_mixins['user_li'](user, i);
-                    i++;
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
+
+    // userscomplex.jade compiled template
+    templatizer["userscomplex"] = function tmpl_userscomplex(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
+                    }
                 }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
 
-// userscomplex.jade compiled template
-exports["userscomplex"] = function tmpl_userscomplex(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
-                }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
-                }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
-
-
-// attach to window or export with commonJS
-if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
-    module.exports = exports;
-} else if (typeof define === "function" && define.amd) {
-    define(exports);
-} else {
-    root.templatizer = exports;
-}
-
-})();
+    return templatizer;
+}));

--- a/test/tests-bundle.js
+++ b/test/tests-bundle.js
@@ -1,494 +1,280 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-(function (global){
-//jade runtime
-(function () {
-var exports; //work in browserify
-!function(e){if("object"==typeof exports)module.exports=e();else if("function"==typeof define&&define.amd)define(e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.jade=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
-'use strict';
-
-/**
- * Merge two attribute objects giving precedence
- * to values in object `b`. Classes are special-cased
- * allowing for arrays and merging/joining appropriately
- * resulting in a string.
- *
- * @param {Object} a
- * @param {Object} b
- * @return {Object} a
- * @api private
- */
-
-exports.merge = function merge(a, b) {
-  if (arguments.length === 1) {
-    var attrs = a[0];
-    for (var i = 1; i < a.length; i++) {
-      attrs = merge(attrs, a[i]);
-    }
-    return attrs;
-  }
-  var ac = a['class'];
-  var bc = b['class'];
-
-  if (ac || bc) {
-    ac = ac || [];
-    bc = bc || [];
-    if (!Array.isArray(ac)) ac = [ac];
-    if (!Array.isArray(bc)) bc = [bc];
-    a['class'] = ac.concat(bc).filter(nulls);
-  }
-
-  for (var key in b) {
-    if (key != 'class') {
-      a[key] = b[key];
-    }
-  }
-
-  return a;
-};
-
-/**
- * Filter null `val`s.
- *
- * @param {*} val
- * @return {Boolean}
- * @api private
- */
-
-function nulls(val) {
-  return val != null && val !== '';
-}
-
-/**
- * join array as classes.
- *
- * @param {*} val
- * @return {String}
- */
-exports.joinClasses = joinClasses;
-function joinClasses(val) {
-  return Array.isArray(val) ? val.map(joinClasses).filter(nulls).join(' ') : val;
-}
-
-/**
- * Render the given classes.
- *
- * @param {Array} classes
- * @param {Array.<Boolean>} escaped
- * @return {String}
- */
-exports.cls = function cls(classes, escaped) {
-  var buf = [];
-  for (var i = 0; i < classes.length; i++) {
-    if (escaped && escaped[i]) {
-      buf.push(exports.escape(joinClasses([classes[i]])));
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
     } else {
-      buf.push(joinClasses(classes[i]));
+        root.templatizer = factory();
     }
-  }
-  var text = joinClasses(buf);
-  if (text.length) {
-    return ' class="' + text + '"';
-  } else {
-    return '';
-  }
-};
+}(this, function () {
+    var jade=function(){function r(r){return null!=r&&""!==r}function n(e){return Array.isArray(e)?e.map(n).filter(r).join(" "):e}var e={};return e.merge=function t(n,e){if(1===arguments.length){for(var a=n[0],s=1;s<n.length;s++)a=t(a,n[s]);return a}var i=n["class"],l=e["class"];(i||l)&&(i=i||[],l=l||[],Array.isArray(i)||(i=[i]),Array.isArray(l)||(l=[l]),n["class"]=i.concat(l).filter(r));for(var o in e)"class"!=o&&(n[o]=e[o]);return n},e.joinClasses=n,e.cls=function(r,t){for(var a=[],s=0;s<r.length;s++)t&&t[s]?a.push(e.escape(n([r[s]]))):a.push(n(r[s]));var i=n(a);return i.length?' class="'+i+'"':""},e.attr=function(r,n,t,a){return"boolean"==typeof n||null==n?n?" "+(a?r:r+'="'+r+'"'):"":0==r.indexOf("data")&&"string"!=typeof n?" "+r+"='"+JSON.stringify(n).replace(/'/g,"&apos;")+"'":t?" "+r+'="'+e.escape(n)+'"':" "+r+'="'+n+'"'},e.attrs=function(r,t){var a=[],s=Object.keys(r);if(s.length)for(var i=0;i<s.length;++i){var l=s[i],o=r[l];"class"==l?(o=n(o))&&a.push(" "+l+'="'+o+'"'):a.push(e.attr(l,o,!1,t))}return a.join("")},e.escape=function(r){var n=String(r).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");return n===""+r?r:n},e.rethrow=function a(r,n,e,t){if(!(r instanceof Error))throw r;if(!("undefined"==typeof window&&n||t))throw r.message+=" on line "+e,r;try{t=t||require("fs").readFileSync(n,"utf8")}catch(s){a(r,null,e)}var i=3,l=t.split("\n"),o=Math.max(e-i,0),c=Math.min(l.length,e+i),i=l.slice(o,c).map(function(r,n){var t=n+o+1;return(t==e?"  > ":"    ")+t+"| "+r}).join("\n");throw r.path=n,r.message=(n||"Jade")+":"+e+"\n"+i+"\n\n"+r.message,r},e}();
 
-/**
- * Render the given attribute.
- *
- * @param {String} key
- * @param {String} val
- * @param {Boolean} escaped
- * @param {Boolean} terse
- * @return {String}
- */
-exports.attr = function attr(key, val, escaped, terse) {
-  if ('boolean' == typeof val || null == val) {
-    if (val) {
-      return ' ' + (terse ? key : key + '="' + key + '"');
-    } else {
-      return '';
-    }
-  } else if (0 == key.indexOf('data') && 'string' != typeof val) {
-    return ' ' + key + "='" + JSON.stringify(val).replace(/'/g, '&apos;') + "'";
-  } else if (escaped) {
-    return ' ' + key + '="' + exports.escape(val) + '"';
-  } else {
-    return ' ' + key + '="' + val + '"';
-  }
-};
+    var templatizer = {};
 
-/**
- * Render the given attributes object.
- *
- * @param {Object} obj
- * @param {Object} escaped
- * @return {String}
- */
-exports.attrs = function attrs(obj, terse){
-  var buf = [];
+    // create our folder objects
+    templatizer["otherfolder"] = {};
+    templatizer["otherfolder"]["deep2"] = {};
+    templatizer["otherfolder"]["deepnested"] = {};
 
-  var keys = Object.keys(obj);
+    // 404.jade compiled template
+    templatizer["404"] = function tmpl_404() {
+        return '<div class="page-404">404!</div>';
+    };
 
-  if (keys.length) {
-    for (var i = 0; i < keys.length; ++i) {
-      var key = keys[i]
-        , val = obj[key];
+    // 404withVars.jade compiled template
+    templatizer["404withVars"] = function tmpl_404withVars(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (content) {
+            buf.push('<div class="page-404">' + jade.escape((jade_interp = content || '404') == null ? '' : jade_interp) + '!</div>');
+        }('content' in locals_for_with ? locals_for_with.content : typeof content !== 'undefined' ? content : undefined));
+        return buf.join('');
+    };
 
-      if ('class' == key) {
-        if (val = joinClasses(val)) {
-          buf.push(' ' + key + '="' + val + '"');
-        }
-      } else {
-        buf.push(exports.attr(key, val, false, terse));
-      }
-    }
-  }
+    // otherfolder/deep2/deeptweet.jade compiled template
+    templatizer["otherfolder"]["deep2"]["deeptweet"] = function tmpl_otherfolder_deep2_deeptweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (tweet) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
+        }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
+        return buf.join('');
+    };
 
-  return buf.join('');
-};
+    // otherfolder/deepnested/deeptweet.jade compiled template
+    templatizer["otherfolder"]["deepnested"]["deeptweet"] = function tmpl_otherfolder_deepnested_deeptweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (tweet) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
+        }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
+        return buf.join('');
+    };
 
-/**
- * Escape the given string of `html`.
- *
- * @param {String} html
- * @return {String}
- * @api private
- */
-
-exports.escape = function escape(html){
-  var result = String(html)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-  if (result === '' + html) return html;
-  else return result;
-};
-
-/**
- * Re-throw the given `err` in context to the
- * the jade in `filename` at the given `lineno`.
- *
- * @param {Error} err
- * @param {String} filename
- * @param {String} lineno
- * @api private
- */
-
-exports.rethrow = function rethrow(err, filename, lineno, str){
-  if (!(err instanceof Error)) throw err;
-  if ((typeof window != 'undefined' || !filename) && !str) {
-    err.message += ' on line ' + lineno;
-    throw err;
-  }
-  try {
-    str =  str || _dereq_('fs').readFileSync(filename, 'utf8')
-  } catch (ex) {
-    rethrow(err, null, lineno)
-  }
-  var context = 3
-    , lines = str.split('\n')
-    , start = Math.max(lineno - context, 0)
-    , end = Math.min(lines.length, lineno + context);
-
-  // Error context
-  var context = lines.slice(start, end).map(function(line, i){
-    var curr = i + start + 1;
-    return (curr == lineno ? '  > ' : '    ')
-      + curr
-      + '| '
-      + line;
-  }).join('\n');
-
-  // Alter exception message
-  err.path = filename;
-  err.message = (filename || 'Jade') + ':' + lineno
-    + '\n' + context + '\n\n' + err.message;
-  throw err;
-};
-
-},{"fs":2}],2:[function(_dereq_,module,exports){
-
-},{}]},{},[1])
-(1)
-});
-})();
-
-(function () {
-var root = this, exports = {};
-
-// create our folder objects
-exports["otherfolder"] = {};
-exports["otherfolder"]["deep2"] = {};
-exports["otherfolder"]["deepnested"] = {};
-
-// 404.jade compiled template
-exports["404"] = function tmpl_404() {
-    return '<div class="page-404">404!</div>';
-};
-
-// 404withVars.jade compiled template
-exports["404withVars"] = function tmpl_404withVars(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (content) {
-        buf.push('<div class="page-404">' + jade.escape((jade_interp = content || '404') == null ? '' : jade_interp) + '!</div>');
-    }('content' in locals_for_with ? locals_for_with.content : typeof content !== 'undefined' ? content : undefined));
-    return buf.join('');
-};
-
-// otherfolder/deep2/deeptweet.jade compiled template
-exports["otherfolder"]["deep2"]["deeptweet"] = function tmpl_otherfolder_deep2_deeptweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (tweet) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
-    }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
-    return buf.join('');
-};
-
-// otherfolder/deepnested/deeptweet.jade compiled template
-exports["otherfolder"]["deepnested"]["deeptweet"] = function tmpl_otherfolder_deepnested_deeptweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (tweet) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = tweet) ? '' : jade_interp) + '</li>');
-    }('tweet' in locals_for_with ? locals_for_with.tweet : typeof tweet !== 'undefined' ? tweet : undefined));
-    return buf.join('');
-};
-
-// otherfolder/nestedMixin.jade compiled template
-exports["otherfolder"]["nestedMixin"] = function tmpl_otherfolder_nestedMixin(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        var i = 0;
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push(exports.otherfolder.nestedMixin.user_li(user, i));
-                    i++;
+    // otherfolder/nestedMixin.jade compiled template
+    templatizer["otherfolder"]["nestedMixin"] = function tmpl_otherfolder_nestedMixin(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            var i = 0;
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push(templatizer.otherfolder.nestedMixin.user_li(user, i));
+                        i++;
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push(templatizer.otherfolder.nestedMixin.user_li(user, i));
+                        i++;
+                    }
                 }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push(exports.otherfolder.nestedMixin.user_li(user, i));
-                    i++;
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
+
+    // otherfolder/nestedMixin.jade:user_li compiled template
+    templatizer["otherfolder"]["nestedMixin"]["user_li"] = function tmpl_otherfolder_nestedMixin_user_li(user, index) {
+        var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
+        buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + ">test</li>");
+        return buf.join("");
+    };
+
+    // otherfolder/othertweet.jade compiled template
+    templatizer["otherfolder"]["othertweet"] = function tmpl_otherfolder_othertweet(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (user) {
+            buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = user) ? '' : jade_interp) + '</li>');
+        }('user' in locals_for_with ? locals_for_with.user : typeof user !== 'undefined' ? user : undefined));
+        return buf.join('');
+    };
+
+    // underscoreUsers.jade compiled template
+    templatizer["underscoreUsers"] = function tmpl_underscoreUsers(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users, _) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
+                    }
                 }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined, '_' in locals_for_with ? locals_for_with._ : typeof _ !== 'undefined' ? _ : undefined));
+        return buf.join('');
+    };
 
-// otherfolder/nestedMixin.jade:user_li compiled template
-exports["otherfolder"]["nestedMixin"]["user_li"] = function tmpl_otherfolder_nestedMixin_user_li(user, index) {
-    var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
-    buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + ">test</li>");
-    return buf.join("");
-};
+    // users.jade compiled template
+    templatizer["users"] = function tmpl_users(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
+                    }
+                }
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
 
-// otherfolder/othertweet.jade compiled template
-exports["otherfolder"]["othertweet"] = function tmpl_otherfolder_othertweet(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (user) {
-        buf.push('<li class="tweet">' + jade.escape(null == (jade_interp = user) ? '' : jade_interp) + '</li>');
-    }('user' in locals_for_with ? locals_for_with.user : typeof user !== 'undefined' ? user : undefined));
-    return buf.join('');
-};
-
-// underscoreUsers.jade compiled template
-exports["underscoreUsers"] = function tmpl_underscoreUsers(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users, _) {
+    // usersLocals.jade compiled template
+    templatizer["usersLocals"] = function tmpl_usersLocals(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
         buf.push('<ul>');
         (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
-                }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push('<li>' + jade.escape((jade_interp = _.isObject(user) && _.isString(user.name) ? user.name : '') == null ? '' : jade_interp) + '</li>');
-                }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined, '_' in locals_for_with ? locals_for_with._ : typeof _ !== 'undefined' ? _ : undefined));
-    return buf.join('');
-};
-
-// users.jade compiled template
-exports["users"] = function tmpl_users(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
+            var $obj = locals.users;
+            if ('number' == typeof $obj.length) {
+                for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                    var user = $obj[$index];
                     buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
                 }
             } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
+                var $l = 0;
+                for (var $index in $obj) {
+                    $l++;
+                    var user = $obj[$index];
                     buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
                 }
             }
         }.call(this));
         buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+        return buf.join('');
+    };
 
-// usersLocals.jade compiled template
-exports["usersLocals"] = function tmpl_usersLocals(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    buf.push('<ul>');
-    (function () {
-        var $$obj = locals.users;
-        if ('number' == typeof $$obj.length) {
-            for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                var user = $$obj[$index];
-                buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
-            }
-        } else {
-            var $$l = 0;
-            for (var $index in $$obj) {
-                $$l++;
-                var user = $$obj[$index];
-                buf.push('<li>' + jade.escape(null == (jade_interp = user.name) ? '' : jade_interp) + '</li>');
-            }
-        }
-    }.call(this));
-    buf.push('</ul>');
-    return buf.join('');
-};
-
-// usersMixins.jade compiled template
-exports["usersMixins"] = function tmpl_usersMixins(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        var i = 0;
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push(exports.usersMixins.user_li(user, i));
-                    i++;
+    // usersMixins.jade compiled template
+    templatizer["usersMixins"] = function tmpl_usersMixins(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            var i = 0;
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push(templatizer.usersMixins.user_li(user, i));
+                        i++;
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push(templatizer.usersMixins.user_li(user, i));
+                        i++;
+                    }
                 }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push(exports.usersMixins.user_li(user, i));
-                    i++;
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
+
+    // usersMixins.jade:user_li compiled template
+    templatizer["usersMixins"]["user_li"] = function tmpl_usersMixins_user_li(user, index) {
+        var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
+        buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + "><span>Before</span>");
+        buf.push(templatizer.usersMixins.user_a(user, index));
+        buf.push("</li>");
+        return buf.join("");
+    };
+
+    // usersMixins.jade:user_a compiled template
+    templatizer["usersMixins"]["user_a"] = function tmpl_usersMixins_user_a(user, index) {
+        var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
+        buf.push("<a" + jade.attr("href", user.url, true, false) + jade.attr("data-user-index", index, true, false) + ">Within " + jade.escape((jade_interp = user.name) == null ? "" : jade_interp) + "</a>");
+        return buf.join("");
+    };
+
+    // userscomplex.jade compiled template
+    templatizer["userscomplex"] = function tmpl_userscomplex(locals) {
+        var buf = [];
+        var jade_mixins = {};
+        var jade_interp;
+        var locals_for_with = locals || {};
+        (function (users) {
+            buf.push('<ul>');
+            (function () {
+                var $obj = users;
+                if ('number' == typeof $obj.length) {
+                    for (var $index = 0, $l = $obj.length; $index < $l; $index++) {
+                        var user = $obj[$index];
+                        buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
+                    }
+                } else {
+                    var $l = 0;
+                    for (var $index in $obj) {
+                        $l++;
+                        var user = $obj[$index];
+                        buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
+                    }
                 }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
+            }.call(this));
+            buf.push('</ul>');
+        }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
+        return buf.join('');
+    };
 
-// usersMixins.jade:user_li compiled template
-exports["usersMixins"]["user_li"] = function tmpl_usersMixins_user_li(user, index) {
-    var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
-    buf.push("<li" + jade.attr("data-user-id", user.id, true, false) + jade.attr("data-user-index", index, true, false) + "><span>Before</span>");
-    buf.push(exports.usersMixins.user_a(user, index));
-    buf.push("</li>");
-    return buf.join("");
-};
+    return templatizer;
+}));
+},{"fs":2}],2:[function(require,module,exports){
 
-// usersMixins.jade:user_a compiled template
-exports["usersMixins"]["user_a"] = function tmpl_usersMixins_user_a(user, index) {
-    var block = this && this.block, attributes = this && this.attributes || {}, buf = [], jade_interp;
-    buf.push("<a" + jade.attr("href", user.url, true, false) + jade.attr("data-user-index", index, true, false) + ">Within " + jade.escape((jade_interp = user.name) == null ? "" : jade_interp) + "</a>");
-    return buf.join("");
-};
-
-// userscomplex.jade compiled template
-exports["userscomplex"] = function tmpl_userscomplex(locals) {
-    var buf = [];
-    var jade_mixins = {};
-    var jade_interp;
-    var locals_for_with = locals || {};
-    (function (users) {
-        buf.push('<ul>');
-        (function () {
-            var $$obj = users;
-            if ('number' == typeof $$obj.length) {
-                for (var $index = 0, $$l = $$obj.length; $index < $$l; $index++) {
-                    var user = $$obj[$index];
-                    buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
-                }
-            } else {
-                var $$l = 0;
-                for (var $index in $$obj) {
-                    $$l++;
-                    var user = $$obj[$index];
-                    buf.push('<li' + jade.attr('data-user-id', user.id, true, false) + '><span>Before</span><a' + jade.attr('href', user.url, true, false) + '>Within ' + jade.escape((jade_interp = user.name) == null ? '' : jade_interp) + '</a></li>');
-                }
-            }
-        }.call(this));
-        buf.push('</ul>');
-    }('users' in locals_for_with ? locals_for_with.users : typeof users !== 'undefined' ? users : undefined));
-    return buf.join('');
-};
-
-
-// attach to window or export with commonJS
-if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
-    module.exports = exports;
-} else if (typeof define === "function" && define.amd) {
-    define(exports);
-} else {
-    root.templatizer = exports;
-}
-
-})();
-}).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],2:[function(require,module,exports){
+},{}],3:[function(require,module,exports){
 /* globals test, ok */
 
 var t = require('../demo_output.js');
@@ -521,4 +307,4 @@ module.exports = {
 
 module.exports.start();
 
-},{"../demo_output.js":1}]},{},[2])
+},{"../demo_output.js":1}]},{},[3])


### PR DESCRIPTION
Closes #51 
- Use an output template file since it's a little easier than joining arrays of strings
- Minify the jade runtime and use it locally inside our factory
- Use latest UMD in the output template so it works with requirejs and browserify
