### PR TITLE
Glob support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 # Custom
 test/tests-bundle.js
 test/underscore.js
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "escodegen": "0.0.26",
     "esprima": "^1.2.1",
     "falafel": "^0.3.1",
+    "glob": "^4.3.5",
     "jade": "^1.7.0",
     "minimist": "^0.1.0",
     "uglify-js": "^2.4.0",


### PR DESCRIPTION
As discussed on issue #74 here is a stab at adding glob support. Glob returns an array with the string value of the path if it's not a glob, so we can still support the existing API (see [here](https://github.com/newtriks/templatizer/compare/HenrikJoreteg:master...master#diff-db17396ce645e08f6823b4f55bac7029R37)). 

If a glob is passed, then an array of `.jade` files should be returned. Keeping inline with as much of your existing logic I iterate through and remove the filenames supporting template directories only. To do this plus prevent another unnecessary loop I build on this [`map`](https://github.com/newtriks/templatizer/compare/HenrikJoreteg:master...master#diff-db17396ce645e08f6823b4f55bac7029L71). I refactored the [`forEach`](https://github.com/newtriks/templatizer/compare/HenrikJoreteg:master...master#diff-db17396ce645e08f6823b4f55bac7029L75) to chain this sequence of events, if you want me to remove that I am happy to refactor. Some of the benchmark times increase very very slightly with the addition of globbing support.