### PR TITLE
allow users to ignore some files and match others in the same directory

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,6 +4,7 @@ var outputPath = path.resolve(__dirname, 'test/builtTemplates');
 var tmplPath = path.resolve(__dirname, 'test/templates');
 var tmplPath2 = path.resolve(__dirname, 'test/templates2');
 var globPath = path.resolve(__dirname, 'test/templates') + '/*.jade';
+var negativeGlobPath = path.resolve(__dirname, 'test/templates') + '/*.jade';
 
 templatizer(tmplPath, path.resolve(outputPath, 'no_mixins.js'), {
     dontTransformMixins: true,
@@ -37,6 +38,14 @@ templatizer(globPath, path.resolve(outputPath, 'glob.js'), {
     namespace: 'glob'
 });
 
+templatizer(negativeGlobPath, path.resolve(outputPath, 'negativeglob.js'), {
+    namespace: 'negativeglob',
+    globOptions: {
+        ignore: ['**/users*']
+    }
+});
+
 templatizer(tmplPath, path.resolve(outputPath, 'amdtemplates.js'), {
     amdDependencies: ['module1']
 });
+

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "glob": "^4.3.5",
     "jade": "^1.9.2",
     "lodash": "^3.2.0",
+    "minimatch": "^2.0.7",
     "minimist": "^0.1.0",
     "uglify-js": "^2.4.0",
     "walkdir": "0.0.7"

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,7 @@
     <script src="builtTemplates/bad_namespaced2.js"></script>
     <script src="builtTemplates/dont_remove_mixins.js"></script>
     <script src="builtTemplates/glob.js"></script>
+    <script src="builtTemplates/negativeglob.js"></script>
     <script src="tests.js"></script>
     <script src="tests-browserify-bundle.js"></script>
     <script src="require.js" config="requre-config.js"></script>

--- a/test/setup.js
+++ b/test/setup.js
@@ -5,6 +5,7 @@ var dontRemoveMixins = {};
 var unaltered = {};
 var multipleDirs = {};
 var glob = {};
+var negativeglob = {};
 var app = { nested: {}, isBoolean: true };
 
 var globalError1 = 'templatizer: window["app"]["isBoolean"] does not exist or is not an object';
@@ -16,7 +17,6 @@ window.onerror = function (errorMsg, url, lineNumber, columnNumber, err) {
     globalErrorCount++;
 
     var isExpected = (err.message === globalError1 || err.message === globalError2);
-
     test('global error ' + globalErrorCount, function () {
         ok(isExpected);
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,4 +1,4 @@
-/* globals test, ok, equal, templatizer, unaltered, multipleDirs, dontRemoveMixins, app, _, globalErrorCount, glob */
+/* globals test, ok, equal, templatizer, unaltered, multipleDirs, dontRemoveMixins, app, _, globalErrorCount, glob, negativeglob */
 
 var data = {
     users: [{
@@ -20,7 +20,7 @@ test("Test mixins", function () {
     var users = templatizer.usersMixins({users: data.users});
     var user_li = templatizer.usersMixins.user_li(data.users[0], 0);
     var user_a = templatizer.usersMixins.user_a(data.users[0], 0);
-    
+
     var _users = '<ul>';
     for (var i = 0, m = data.users.length; i < m; i++) {
         _users += templatizer.usersMixins.user_li(data.users[i], i);
@@ -41,7 +41,7 @@ test("Test calling templates with different context", function () {
     var users = usersObj.template({users: data.users});
     var user_li = user_liObj.template(data.users[0], 0);
     var user_a = user_aObj.template(data.users[0], 0);
-    
+
     var _users = '<ul>';
     for (var i = 0, m = data.users.length; i < m; i++) {
         _users += templatizer.usersMixins.user_li(data.users[i], i);
@@ -167,4 +167,12 @@ test('Glob produces templatizer functions', function () {
     equal(typeof glob.templatizer.otherfolder.nestedMixin, 'function');
     equal(typeof glob.templatizer.usersMixins, 'function');
     equal(glob.templatizer['404'](), '<div class="page-404">404!</div>');
+});
+
+
+test('Negative Glob doesnt produce matching templatizer functions', function () {
+    equal(typeof negativeglob.templatizer.otherfolder.deepnested.deeptweet, 'function');
+    equal(typeof negativeglob.templatizer.otherfolder.nestedMixin, 'function');
+    equal(typeof negativeglob.templatizer.users, 'undefined');
+    equal(typeof negativeglob.templatizer.usersMixins, 'undefined');
 });


### PR DESCRIPTION
I gave another try at fixing https://github.com/HenrikJoreteg/templatizer/issues/79 
I was finally able to pass the test by replicating the config used in the last TravisCI passing test :) 

The logic changed a bit since `node-glob` deprecate the use of negative patterns in favor of an `ignore` options.

Tell me what you think of it :) 