### PR TITLE
Add jade_interp declaration to mixin for use in 'strict mode'

### DIFF
--- a/lib/transformMixins.js
+++ b/lib/transformMixins.js
@@ -19,6 +19,16 @@ function bufDeclartion(name) {
     };
 }
 
+function jadeInterpDeclaration() {
+    return {
+        "type": "VariableDeclarator",
+        "id": {
+            "type": "Identifier",
+            "name": "jade_interp"
+        }
+    };
+}
+
 function returnBuf(name) {
     return {
         "type": "ReturnStatement",
@@ -114,6 +124,9 @@ function findAndReplaceMixin(node, options) {
 
         // Add buffer array to variable declarations
         mixinStatements[0].declarations.push(bufDeclartion());
+
+        // Add jade_interp declaration for use in 'strict mode'
+        mixinStatements[0].declarations.push(jadeInterpDeclaration());
 
         // Return the buffer joined as a string from the function
         mixinStatements.push(returnBuf());


### PR DESCRIPTION
I've added `jade_interp` declaration to mixin function. Now generated template files can be required for borwser use with webpack and babel, which enables strict mode for every module.