### PR TITLE
Fix file skipping issue in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "minimatch": "^3.0.3",
     "minimist": "^1.1.3",
     "uglify-js": "^2.4.24",
-    "walkdir": "0.0.11"
+    "walkdir": "0.0.12"
   },
   "devDependencies": {
     "@lukekarrys/jade-runtime": "^1.11.1",

--- a/templatizer.js
+++ b/templatizer.js
@@ -122,7 +122,10 @@ module.exports = function (input, output, options, done) {
             var conflicts = [];
             async.each(directories, function (dir, dirDone) {
                 var files = [];
-                var walker = walkdir(dir);
+                var walker = walkdir(dir, {
+                  max_depth: 20,
+                  track_inodes: false
+                });
                 walker.on('path', function (file) {
                     files.push(file);
                 });


### PR DESCRIPTION
- Update walkdir version
- Add "track_inodes: false" option to avoid file skipping in Windows
- Add "max_depth: 20" option to avoid infinite loop that can be occured because of previous option

https://github.com/soldair/node-walkdir/commit/007ca514ddef991e9ec0130768bc004189c0a4d9